### PR TITLE
Issue #13612 Fixed. 

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/AbstractSource.php
@@ -73,7 +73,7 @@ abstract class AbstractSource implements
             }
         }
         // End
-        if (isset($options[$value])) {
+        if (is_null($value) === false  &&  is_array($value) === false && isset($options) && isset($options[$value])) {
             return $options[$value];
         }
         return false;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

   The function `getOptionText` expects params as string or integer and in case of `quantity_and_stock_status` when visibility set to storefront , array passed to `getOptionText` which can be handled by adding `is_array` check for param `$value`.   

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2 #13612: Issue title **1 exception(s): Exception #0 (Exception): Warning: Illegal offset type in isset or empty in /Model/Entity/Attribute/Source/AbstractSource.php on line 76**


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->


### Contribution checklist (*)
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
